### PR TITLE
Add a wildcard to URAM inference constraint

### DIFF
--- a/hdk/cl/developer_designs/cl_firesim/build/constraints/cl_synth_user.xdc
+++ b/hdk/cl/developer_designs/cl_firesim/build/constraints/cl_synth_user.xdc
@@ -1,28 +1,3 @@
 # This contains the CL specific constraints for synthesis at the CL level
 
-#get_cells firesim_top/top/SimpleNICWidget_0/incomingPCISdat/BRAMQueue/fq/ram*
-
-set_property RAM_STYLE ULTRA [get_cells firesim_top/top/SimpleNICWidget_0/incomingPCISdat/BRAMQueue/fq/ram_reg]
-set_property RAM_STYLE ULTRA [get_cells firesim_top/top/SimpleNICWidget_0/outgoingPCISdat/BRAMQueue/fq/ram_reg]
-
-set_property RAM_STYLE ULTRA [get_cells firesim_top/top/SimpleNICWidget_1/incomingPCISdat/BRAMQueue/fq/ram_reg]
-set_property RAM_STYLE ULTRA [get_cells firesim_top/top/SimpleNICWidget_1/incomingPCISdat/BRAMQueue/fq/ram_reg]
-
-set_property RAM_STYLE ULTRA [get_cells firesim_top/top/SimpleNICWidget_2/incomingPCISdat/BRAMQueue/fq/ram_reg]
-set_property RAM_STYLE ULTRA [get_cells firesim_top/top/SimpleNICWidget_2/outgoingPCISdat/BRAMQueue/fq/ram_reg]
-
-set_property RAM_STYLE ULTRA [get_cells firesim_top/top/SimpleNICWidget_3/outgoingPCISdat/BRAMQueue/fq/ram_reg]
-set_property RAM_STYLE ULTRA [get_cells firesim_top/top/SimpleNICWidget_3/outgoingPCISdat/BRAMQueue/fq/ram_reg]
-
-set_property RAM_STYLE ULTRA [get_cells firesim_top/top/SimpleNICWidget_4/outgoingPCISdat/BRAMQueue/fq/ram_reg]
-set_property RAM_STYLE ULTRA [get_cells firesim_top/top/SimpleNICWidget_4/outgoingPCISdat/BRAMQueue/fq/ram_reg]
-
-set_property RAM_STYLE ULTRA [get_cells firesim_top/top/SimpleNICWidget_5/outgoingPCISdat/BRAMQueue/fq/ram_reg]
-set_property RAM_STYLE ULTRA [get_cells firesim_top/top/SimpleNICWidget_5/outgoingPCISdat/BRAMQueue/fq/ram_reg]
-
-set_property RAM_STYLE ULTRA [get_cells firesim_top/top/SimpleNICWidget_6/outgoingPCISdat/BRAMQueue/fq/ram_reg]
-set_property RAM_STYLE ULTRA [get_cells firesim_top/top/SimpleNICWidget_6/outgoingPCISdat/BRAMQueue/fq/ram_reg]
-
-set_property RAM_STYLE ULTRA [get_cells firesim_top/top/SimpleNICWidget_7/outgoingPCISdat/BRAMQueue/fq/ram_reg]
-set_property RAM_STYLE ULTRA [get_cells firesim_top/top/SimpleNICWidget_7/outgoingPCISdat/BRAMQueue/fq/ram_reg]
-
+set_property RAM_STYLE ULTRA [get_cells -hierarchical -regexp firesim_top.*PCISdat/fq/ram_reg.*]


### PR DESCRIPTION
Should work for any endpoint using the DMA Transport traits. 

I broke the constraints when i did the refactoring since the path changed. 