### PR TITLE
Fix FPGA-level Simulation

### DIFF
--- a/hdk/cl/developer_designs/cl_firesim/software/runtime/common_dma.c
+++ b/hdk/cl/developer_designs/cl_firesim/software/runtime/common_dma.c
@@ -163,6 +163,7 @@ out:
     return rc;
 }
 
+// Biancolin: We don't use these but their callouts to the SV task that implements them has changed.
 //void fpga_read_cl_to_buffer(int slot_id, int channel, int fd, size_t buffer_size, size_t address) {
 //#ifdef SV_TEST
 //  sv_fpga_start_cl_to_buffer(slot_id, channel, buffer_size, address);

--- a/hdk/cl/developer_designs/cl_firesim/software/runtime/common_dma.c
+++ b/hdk/cl/developer_designs/cl_firesim/software/runtime/common_dma.c
@@ -163,22 +163,22 @@ out:
     return rc;
 }
 
-void fpga_read_cl_to_buffer(int slot_id, int channel, int fd, size_t buffer_size, size_t address) {
-#ifdef SV_TEST
-  sv_fpga_start_cl_to_buffer(slot_id, channel, buffer_size, address);
-#else
-  fpga_driver_read_cl_to_buffer(slot_id, channel, fd, buffer_size, address);
-#endif
-  dma_memcmp(buffer_size);
-}
-
-void fpga_write_buffer_to_cl(int slot_id, int channel, int fd, size_t buffer_size, size_t address){
-#ifdef SV_TEST
-  sv_fpga_start_buffer_to_cl(slot_id, channel, buffer_size, write_buffer, address);
-#else
-  fpga_driver_write_buffer_to_cl(slot_id, channel, fd, buffer_size, address);
-#endif
-}
+//void fpga_read_cl_to_buffer(int slot_id, int channel, int fd, size_t buffer_size, size_t address) {
+//#ifdef SV_TEST
+//  sv_fpga_start_cl_to_buffer(slot_id, channel, buffer_size, address);
+//#else
+//  fpga_driver_read_cl_to_buffer(slot_id, channel, fd, buffer_size, address);
+//#endif
+//  dma_memcmp(buffer_size);
+//}
+//
+//void fpga_write_buffer_to_cl(int slot_id, int channel, int fd, size_t buffer_size, size_t address){
+//#ifdef SV_TEST
+//  sv_fpga_start_buffer_to_cl(slot_id, channel, buffer_size, write_buffer, address);
+//#else
+//  fpga_driver_write_buffer_to_cl(slot_id, channel, fd, buffer_size, address);
+//#endif
+//}
 
 int dma_memcmp (size_t buffer_size) {
    int rc = 0;

--- a/hdk/cl/developer_designs/cl_firesim/software/runtime/common_dma.h
+++ b/hdk/cl/developer_designs/cl_firesim/software/runtime/common_dma.h
@@ -55,9 +55,9 @@ int fpga_driver_write_buffer_to_cl(int slot_id, int channel, int fd, size_t buff
 
 int fpga_driver_read_cl_to_buffer(int slot_id, int channel, int fd, size_t buffer_size, size_t address);
 
-void fpga_write_buffer_to_cl(int slot_id, int channel, int fd, size_t buffer_size, size_t address);
-
-void fpga_read_cl_to_buffer(int slot_id, int channel, int fd, size_t buffer_size, size_t address);
+//void fpga_write_buffer_to_cl(int slot_id, int channel, int fd, size_t buffer_size, size_t address);
+//
+//void fpga_read_cl_to_buffer(int slot_id, int channel, int fd, size_t buffer_size, size_t address);
 
 int dma_example_hwsw_cosim(int slot_id);
 

--- a/hdk/cl/developer_designs/cl_firesim/software/runtime/common_dma.h
+++ b/hdk/cl/developer_designs/cl_firesim/software/runtime/common_dma.h
@@ -55,6 +55,7 @@ int fpga_driver_write_buffer_to_cl(int slot_id, int channel, int fd, size_t buff
 
 int fpga_driver_read_cl_to_buffer(int slot_id, int channel, int fd, size_t buffer_size, size_t address);
 
+// Biancolin: We don't use these but their callouts to the SV task that implements them has changed.
 //void fpga_write_buffer_to_cl(int slot_id, int channel, int fd, size_t buffer_size, size_t address);
 //
 //void fpga_read_cl_to_buffer(int slot_id, int channel, int fd, size_t buffer_size, size_t address);

--- a/hdk/cl/developer_designs/cl_firesim/verif/scripts/Makefile
+++ b/hdk/cl/developer_designs/cl_firesim/verif/scripts/Makefile
@@ -57,11 +57,16 @@ export SH_SH_DIR   = $(HDK_SHELL_DESIGN_DIR)/sh_ddr/sim
 SV_TEST_LIST = test_firesim
 C_FILES      = $(C_TEST_NAME) $(C_SDK_USR_UTILS_DIR)/sh_dpi_tasks.c $(C_COMMON_DIR)/src/fpga_pci_sv.c $(C_SRC_DIR)/common_dma.c
 
+ELABORATED_IP_FILES = $(CL_ROOT)/ip/clk_wiz_0_firesim/clk_wiz_0_firesim_sim_netlist.v
+
 ifeq ($(XCHK), 1)
   all:	make_sim_dir compile_chk run
 else
   all:	make_sim_dir compile run
 endif
+
+$(CL_ROOT)/ip/clk_wiz_0_firesim/clk_wiz_0_firesim_sim_netlist.v:
+	vivado -mode tcl -source synth_firesim_clk_wiz_sim.tcl -tclargs $(CL_ROOT)
 
 include $(HDK_COMMON_DIR)/verif/tb/scripts/Makefile.common.inc
 

--- a/hdk/cl/developer_designs/cl_firesim/verif/scripts/Makefile.vcs
+++ b/hdk/cl/developer_designs/cl_firesim/verif/scripts/Makefile.vcs
@@ -22,11 +22,11 @@
 ## 2. make all VCS=1  -> Runs the test
 ##################################################################
 
-compile: $(COMPLIB_DIR)
+compile: $(COMPLIB_DIR) $(ELABORATED_IP_FILES)
 	mkdir -p $(SIM_DIR)
 	cd ${SIM_DIR} && ln -s -f ../vcs_complib/synopsys_sim.setup
 	cd $(SIM_DIR) && vlogan -ntb_opts tb_timescale=1ps/1ps -timescale=1ps/1ps -sverilog +systemverilogext+.sv +libext+.sv +libext+.v -full64 -lca -v2005 +v2k -l compile.vlogan.log -f $(SCRIPTS_DIR)/top.$(SIMULATOR).f +define+VCS +define+DMA_TEST $(DEFINES) +lint=TFIPC-L
-	cd $(SIM_DIR) && vcs tb $(TEST) $(C_FILES) -CFLAGS "-I$(C_SDK_USR_INC_DIR)" -CFLAGS "-I$(C_SDK_USR_UTILS_DIR)" -CFLAGS "-I$(C_COMMON_DIR)/include" -CFLAGS "-I$(C_COMMON_DIR)/src" -CFLAGS "-DSV_TEST" -CFLAGS "-DSCOPE" -CFLAGS "-I$(C_INC_DIR)" "-I$(C_SRC_DIR)" -debug_all -M -I +lint=TFIPC-L -debug_pp glbl -ntb_opts tb_timescale=1ps/1ps -timescale=1ps/1ps -sverilog -full64 +memcbk -licqueue -lca -v2005 -l compile.vcs.log
+	cd $(SIM_DIR) && vcs tb $(TEST) $(C_FILES) -CFLAGS "-I$(C_SDK_USR_INC_DIR)" -CFLAGS "-I$(C_SDK_USR_UTILS_DIR)" -CFLAGS "-I$(C_COMMON_DIR)/include" -CFLAGS "-I$(C_COMMON_DIR)/src" -CFLAGS "-DSV_TEST" -CFLAGS "-DSCOPE" -CFLAGS "-I$(C_INC_DIR)" "-I$(C_SRC_DIR)" -debug_all -M -debug_access+nomemcbk+dmptf -debug_region+cell +lint=TFIPC-L -debug_pp glbl -ntb_opts tb_timescale=1ps/1ps -timescale=1ps/1ps -sverilog -full64 +memcbk -licqueue -lca -v2005 -l compile.vcs.log
 
 run:
 

--- a/hdk/cl/developer_designs/cl_firesim/verif/scripts/Makefile.vivado
+++ b/hdk/cl/developer_designs/cl_firesim/verif/scripts/Makefile.vivado
@@ -17,7 +17,7 @@
 ## Makefile For Vivado compiles and simulations
 ##################################################################
 
-compile:
+compile: $(ELABORATED_IP_FILES)
 	mkdir -p $(SIM_DIR)
 	cd $(SIM_DIR) && xsc $(C_FILES) --additional_option "-I$(C_SDK_USR_INC_DIR)" --additional_option "-I$(C_SDK_USR_UTILS_DIR)" --additional_option "-I$(C_COMMON_DIR)/include" --additional_option "-I$(C_COMMON_DIR)/src" --additional_option "-I$(C_INC_DIR)"  --additional_option "-DVIVADO_SIM" --additional_option "-DSV_TEST" --additional_option "-DDMA_TEST"
 	cd $(SIM_DIR) && xvlog --sv -m64 --define DMA_TEST --initfile $(XILINX_VIVADO)/data/xsim/ip/xsim_ip.ini --work xil_defaultlib --relax -f $(SCRIPTS_DIR)/top.vivado.f

--- a/hdk/cl/developer_designs/cl_firesim/verif/scripts/synth_firesim_clk_wiz_sim.tcl
+++ b/hdk/cl/developer_designs/cl_firesim/verif/scripts/synth_firesim_clk_wiz_sim.tcl
@@ -1,0 +1,5 @@
+set CL_DIR [lindex $argv 0]
+create_project -in_memory -part xcvu9p-flgb2104-2-i -force
+source $CL_DIR/design/cl_firesim_generated_env.tcl
+source $CL_DIR/build/scripts/synth_firesim_clk_wiz.tcl
+exit

--- a/hdk/cl/developer_designs/cl_firesim/verif/scripts/top.vcs.f
+++ b/hdk/cl/developer_designs/cl_firesim/verif/scripts/top.vcs.f
@@ -38,6 +38,7 @@
 
 +incdir+${CL_ROOT}/../common/design
 +incdir+${CL_ROOT}/design
++incdir+${CL_ROOT}/design/ila_files
 +incdir+${CL_ROOT}/verif/sv
 +incdir+${SH_LIB_DIR}
 +incdir+${SH_INF_DIR}

--- a/hdk/cl/developer_designs/cl_firesim/verif/scripts/top.vcs.f
+++ b/hdk/cl/developer_designs/cl_firesim/verif/scripts/top.vcs.f
@@ -27,6 +27,7 @@
 
 -y ${CL_ROOT}/../common/design
 -y ${CL_ROOT}/design
+-y ${CL_ROOT}/design/ila_files
 -y ${CL_ROOT}/verif/sv
 -y ${SH_LIB_DIR}
 -y ${SH_INF_DIR}
@@ -76,6 +77,9 @@ ${CL_ROOT}/ip/clk_wiz_0_firesim/clk_wiz_0_firesim_sim_netlist.v
 ${CL_ROOT}/ip/axi_dwidth_converter_0/sim/axi_dwidth_converter_0.v
 ${CL_ROOT}/ip/axi_dwidth_converter_0/hdl/axi_dwidth_converter_v2_1_vl_rfs.v
 ${CL_ROOT}/ip/axi_dwidth_converter_0/hdl/axi_register_slice_v2_1_vl_rfs.v
+${CL_ROOT}/design/ila_files/firesim_ila_insert_inst.v
+${CL_ROOT}/design/ila_files/firesim_ila_insert_ports.v
+${CL_ROOT}/design/ila_files/firesim_ila_insert_wires.v
 ${CL_ROOT}/design/cl_firesim_generated.sv
 ${CL_ROOT}/design/cl_firesim_generated_defines.vh
 ${CL_ROOT}/design/cl_firesim.sv


### PR DESCRIPTION
FPGA-level simulation was busted mostly because I never added support for synthesizing the PLL that provides the GG-domain clock.