### PR TITLE
FireSim 1.12 Release (Dev -> Master) Tracking PR

### DIFF
--- a/hdk/cl/developer_designs/cl_firesim/build/scripts/create_dcp_from_cl.tcl
+++ b/hdk/cl/developer_designs/cl_firesim/build/scripts/create_dcp_from_cl.tcl
@@ -285,7 +285,7 @@ if {$implement} {
          impl_step opt_design $TOP "-merge_equivalent_drivers -sweep"
       }
    }
-   report_utilization -hierarchical -file $CL_DIR/build/reports/${timestamp}.post_opt_utilization.rpt
+   report_utilization -hierarchical -hierarchical_percentages -file $CL_DIR/build/reports/${timestamp}.post_opt_utilization.rpt
 
    ########################
    # CL Place
@@ -331,7 +331,7 @@ if {$implement} {
    report_timing_summary -file $CL_DIR/build/reports/${timestamp}.SH_CL_final_timing_summary.rpt
 
    # Report utilization
-   report_utilization -hierarchical -file $CL_DIR/build/reports/${timestamp}.SH_CL_utilization.rpt
+   report_utilization -hierarchical -hierarchical_percentages -file $CL_DIR/build/reports/${timestamp}.SH_CL_utilization.rpt
 
    # This is what will deliver to AWS
    puts "AWS FPGA: ([clock format [clock seconds] -format %T]) - Writing final DCP to to_aws directory.";

--- a/hdk/cl/developer_designs/cl_firesim/build/scripts/create_dcp_from_cl.tcl
+++ b/hdk/cl/developer_designs/cl_firesim/build/scripts/create_dcp_from_cl.tcl
@@ -177,6 +177,10 @@ switch $strategy {
         puts "EXPLORE strategy."
         source $HDK_SHELL_DIR/build/scripts/strategy_EXPLORE.tcl
     }
+    "NORETIMING" {
+        puts "NORETIMING strategy."
+        source $HDK_SHELL_DIR/build/scripts/strategy_NORETIMING.tcl
+    }
     "TIMING" {
         puts "TIMING strategy."
         source $HDK_SHELL_DIR/build/scripts/strategy_TIMING.tcl

--- a/hdk/cl/developer_designs/cl_firesim/build/scripts/create_dcp_from_cl.tcl
+++ b/hdk/cl/developer_designs/cl_firesim/build/scripts/create_dcp_from_cl.tcl
@@ -311,17 +311,11 @@ if {$implement} {
    ##############################
    # CL Post-Route Optimization
    ##############################
-   set SLACK [get_property SLACK [get_timing_paths]]
+   set SLACK [get_property -min SLACK [get_timing_paths -delay_type min_max]]
    #Post-route phys_opt will not be run if slack is positive or greater than -200ps.
    if {$route_phys_opt && $SLACK > -0.400 && $SLACK < 0} {
       puts "\nAWS FPGA: ([clock format [clock seconds] -format %T]) - Running post-route optimization";
       impl_step route_phys_opt_design $TOP $post_phys_options $post_phys_directive $post_phys_preHookTcl $post_phys_postHookTcl
-   }
-   # Check if slack has improved after physopt.
-   set SLACK [get_property SLACK [get_timing_paths]]
-   if {$SLACK < 0} {
-      puts "\nFATAL: Design did not meet timing requirements. Terminating.";
-      exit 3
    }
 
    ##############################
@@ -346,6 +340,13 @@ if {$implement} {
 
    # Generate debug probes file
    write_debug_probes -force -no_partial_ltxfile -file $CL_DIR/build/checkpoints/${timestamp}.debug_probes.ltx
+
+   # Before proceeding, coarsely check if we meet timing otherwise exit
+   set SLACK [get_property -min SLACK [get_timing_paths -delay_type min_max]]
+   if {$SLACK < 0} {
+      puts "\nFATAL: Design did not meet timing requirements. Terminating.";
+      exit 3
+   }
 
    close_project
 }

--- a/hdk/cl/developer_designs/cl_firesim/build/scripts/create_dcp_from_cl.tcl
+++ b/hdk/cl/developer_designs/cl_firesim/build/scripts/create_dcp_from_cl.tcl
@@ -147,6 +147,8 @@ set_msg_config -id {Timing 38-436}       -suppress
 # Promote the following critical warnings to errors to prevent AGFI generation
 # Design not completely routed
 set_msg_config -id {Route 35-1} -new_severity "ERROR"
+# Route 35-535] Clock Net: <net> is not completely routed.
+set_msg_config -id {Route 35-535} -new_severity "ERROR"
 
 # Check that an email address has been set, else unset notify_via_sns
 

--- a/hdk/cl/developer_designs/cl_firesim/build/scripts/synth_cl_firesim.tcl
+++ b/hdk/cl/developer_designs/cl_firesim/build/scripts/synth_cl_firesim.tcl
@@ -117,7 +117,7 @@ puts "AWS FPGA: ([clock format [clock seconds] -format %T]) Start design synthes
 
 update_compile_order -fileset sources_1
 puts "\nRunning synth_design for $CL_MODULE $CL_DIR/build/scripts \[[clock format [clock seconds] -format {%a %b %d %H:%M:%S %Y}]\]"
-eval [concat synth_design -top $CL_MODULE -verilog_define XSDB_SLV_DIS $VDEFINES -part [DEVICE_TYPE] -mode out_of_context $synth_options -directive $synth_directive -retiming]
+eval [concat synth_design -top $CL_MODULE -verilog_define XSDB_SLV_DIS $VDEFINES -part [DEVICE_TYPE] -mode out_of_context $synth_options -directive $synth_directive]
 
 set failval [catch {exec grep "FAIL" failfast.csv}]
 if { $failval==0 } {

--- a/hdk/cl/developer_designs/cl_firesim/build/scripts/synth_cl_firesim.tcl
+++ b/hdk/cl/developer_designs/cl_firesim/build/scripts/synth_cl_firesim.tcl
@@ -128,6 +128,9 @@ if { $failval==0 } {
 puts "AWS FPGA: ([clock format [clock seconds] -format %T]) writing post synth checkpoint.";
 write_checkpoint -force $CL_DIR/build/checkpoints/${timestamp}.CL.post_synth.dcp
 
+report_utilization -hierarchical -hierarchical_percentages -file $CL_DIR/build/reports/${timestamp}.post_synth_utilization.rpt
+report_control_sets -verbose -file $CL_DIR/build/reports/${timestamp}.post_synth_control_sets.rpt
+
 close_project
 #Set param back to default value
 set_param sta.enableAutoGenClkNamePersistence 1

--- a/hdk/cl/developer_designs/cl_firesim/design/cl_firesim.sv
+++ b/hdk/cl/developer_designs/cl_firesim/design/cl_firesim.sv
@@ -1089,23 +1089,18 @@ wire fsimtop_s_3_axi_rready;
    .io_slave_0_aw_bits_cache(fsimtop_s_0_axi_awcache), // not available on DDR IF
    .io_slave_0_aw_bits_prot(fsimtop_s_0_axi_awprot), // not available on DDR IF
    .io_slave_0_aw_bits_qos(fsimtop_s_0_axi_awqos), // not available on DDR IF
-   .io_slave_0_aw_bits_region(fsimtop_s_0_axi_awregion), // not available on DDR IF
    .io_slave_0_aw_bits_id(fsimtop_s_0_axi_awid),
-   .io_slave_0_aw_bits_user(), // not available on DDR IF
 
    .io_slave_0_w_ready(fsimtop_s_0_axi_wready),
    .io_slave_0_w_valid(fsimtop_s_0_axi_wvalid),
    .io_slave_0_w_bits_data(fsimtop_s_0_axi_wdata),
    .io_slave_0_w_bits_last(fsimtop_s_0_axi_wlast),
-   .io_slave_0_w_bits_id(),
    .io_slave_0_w_bits_strb(fsimtop_s_0_axi_wstrb),
-   .io_slave_0_w_bits_user(), // not available on DDR IF
 
    .io_slave_0_b_ready(fsimtop_s_0_axi_bready),
    .io_slave_0_b_valid(fsimtop_s_0_axi_bvalid),
    .io_slave_0_b_bits_resp(fsimtop_s_0_axi_bresp),
    .io_slave_0_b_bits_id(fsimtop_s_0_axi_bid),
-   .io_slave_0_b_bits_user(1'b0), // TODO check this
 
    .io_slave_0_ar_ready(fsimtop_s_0_axi_arready),
    .io_slave_0_ar_valid(fsimtop_s_0_axi_arvalid),
@@ -1117,9 +1112,7 @@ wire fsimtop_s_3_axi_rready;
    .io_slave_0_ar_bits_cache(fsimtop_s_0_axi_arcache), // not available on DDR IF
    .io_slave_0_ar_bits_prot(fsimtop_s_0_axi_arprot), // not available on DDR IF
    .io_slave_0_ar_bits_qos(fsimtop_s_0_axi_arqos), // not available on DDR IF
-   .io_slave_0_ar_bits_region(fsimtop_s_0_axi_arregion), // not available on DDR IF
    .io_slave_0_ar_bits_id(fsimtop_s_0_axi_arid), // not available on DDR IF
-   .io_slave_0_ar_bits_user(), // not available on DDR IF
 
    .io_slave_0_r_ready(fsimtop_s_0_axi_rready),
    .io_slave_0_r_valid(fsimtop_s_0_axi_rvalid),
@@ -1127,7 +1120,6 @@ wire fsimtop_s_3_axi_rready;
    .io_slave_0_r_bits_data(fsimtop_s_0_axi_rdata),
    .io_slave_0_r_bits_last(fsimtop_s_0_axi_rlast),
    .io_slave_0_r_bits_id(fsimtop_s_0_axi_rid),
-   .io_slave_0_r_bits_user(1'b0), // TODO check this
 
    .io_slave_1_aw_ready(fsimtop_s_1_axi_awready),
    .io_slave_1_aw_valid(fsimtop_s_1_axi_awvalid),
@@ -1139,23 +1131,18 @@ wire fsimtop_s_3_axi_rready;
    .io_slave_1_aw_bits_cache(fsimtop_s_1_axi_awcache), // not available on DDR IF
    .io_slave_1_aw_bits_prot(fsimtop_s_1_axi_awprot), // not available on DDR IF
    .io_slave_1_aw_bits_qos(fsimtop_s_1_axi_awqos), // not available on DDR IF
-   .io_slave_1_aw_bits_region(fsimtop_s_1_axi_awregion), // not available on DDR IF
    .io_slave_1_aw_bits_id(fsimtop_s_1_axi_awid),
-   .io_slave_1_aw_bits_user(), // not available on DDR IF
 
    .io_slave_1_w_ready(fsimtop_s_1_axi_wready),
    .io_slave_1_w_valid(fsimtop_s_1_axi_wvalid),
    .io_slave_1_w_bits_data(fsimtop_s_1_axi_wdata),
    .io_slave_1_w_bits_last(fsimtop_s_1_axi_wlast),
-   .io_slave_1_w_bits_id(),
    .io_slave_1_w_bits_strb(fsimtop_s_1_axi_wstrb),
-   .io_slave_1_w_bits_user(), // not available on DDR IF
 
    .io_slave_1_b_ready(fsimtop_s_1_axi_bready),
    .io_slave_1_b_valid(fsimtop_s_1_axi_bvalid),
    .io_slave_1_b_bits_resp(fsimtop_s_1_axi_bresp),
    .io_slave_1_b_bits_id(fsimtop_s_1_axi_bid),
-   .io_slave_1_b_bits_user(1'b0), // TODO check this
 
    .io_slave_1_ar_ready(fsimtop_s_1_axi_arready),
    .io_slave_1_ar_valid(fsimtop_s_1_axi_arvalid),
@@ -1167,9 +1154,7 @@ wire fsimtop_s_3_axi_rready;
    .io_slave_1_ar_bits_cache(fsimtop_s_1_axi_arcache), // not available on DDR IF
    .io_slave_1_ar_bits_prot(fsimtop_s_1_axi_arprot), // not available on DDR IF
    .io_slave_1_ar_bits_qos(fsimtop_s_1_axi_arqos), // not available on DDR IF
-   .io_slave_1_ar_bits_region(fsimtop_s_1_axi_arregion), // not available on DDR IF
    .io_slave_1_ar_bits_id(fsimtop_s_1_axi_arid), // not available on DDR IF
-   .io_slave_1_ar_bits_user(), // not available on DDR IF
 
    .io_slave_1_r_ready(fsimtop_s_1_axi_rready),
    .io_slave_1_r_valid(fsimtop_s_1_axi_rvalid),
@@ -1177,8 +1162,6 @@ wire fsimtop_s_3_axi_rready;
    .io_slave_1_r_bits_data(fsimtop_s_1_axi_rdata),
    .io_slave_1_r_bits_last(fsimtop_s_1_axi_rlast),
    .io_slave_1_r_bits_id(fsimtop_s_1_axi_rid),
-   .io_slave_1_r_bits_user(1'b0), // TODO check this
-
 
    .io_slave_2_aw_ready(fsimtop_s_2_axi_awready),
    .io_slave_2_aw_valid(fsimtop_s_2_axi_awvalid),
@@ -1190,23 +1173,18 @@ wire fsimtop_s_3_axi_rready;
    .io_slave_2_aw_bits_cache(fsimtop_s_2_axi_awcache), // not available on DDR IF
    .io_slave_2_aw_bits_prot(fsimtop_s_2_axi_awprot), // not available on DDR IF
    .io_slave_2_aw_bits_qos(fsimtop_s_2_axi_awqos), // not available on DDR IF
-   .io_slave_2_aw_bits_region(fsimtop_s_2_axi_awregion), // not available on DDR IF
    .io_slave_2_aw_bits_id(fsimtop_s_2_axi_awid),
-   .io_slave_2_aw_bits_user(), // not available on DDR IF
 
    .io_slave_2_w_ready(fsimtop_s_2_axi_wready),
    .io_slave_2_w_valid(fsimtop_s_2_axi_wvalid),
    .io_slave_2_w_bits_data(fsimtop_s_2_axi_wdata),
    .io_slave_2_w_bits_last(fsimtop_s_2_axi_wlast),
-   .io_slave_2_w_bits_id(),
    .io_slave_2_w_bits_strb(fsimtop_s_2_axi_wstrb),
-   .io_slave_2_w_bits_user(), // not available on DDR IF
 
    .io_slave_2_b_ready(fsimtop_s_2_axi_bready),
    .io_slave_2_b_valid(fsimtop_s_2_axi_bvalid),
    .io_slave_2_b_bits_resp(fsimtop_s_2_axi_bresp),
    .io_slave_2_b_bits_id(fsimtop_s_2_axi_bid),
-   .io_slave_2_b_bits_user(1'b0), // TODO check this
 
    .io_slave_2_ar_ready(fsimtop_s_2_axi_arready),
    .io_slave_2_ar_valid(fsimtop_s_2_axi_arvalid),
@@ -1218,9 +1196,7 @@ wire fsimtop_s_3_axi_rready;
    .io_slave_2_ar_bits_cache(fsimtop_s_2_axi_arcache), // not available on DDR IF
    .io_slave_2_ar_bits_prot(fsimtop_s_2_axi_arprot), // not available on DDR IF
    .io_slave_2_ar_bits_qos(fsimtop_s_2_axi_arqos), // not available on DDR IF
-   .io_slave_2_ar_bits_region(fsimtop_s_2_axi_arregion), // not available on DDR IF
    .io_slave_2_ar_bits_id(fsimtop_s_2_axi_arid), // not available on DDR IF
-   .io_slave_2_ar_bits_user(), // not available on DDR IF
 
    .io_slave_2_r_ready(fsimtop_s_2_axi_rready),
    .io_slave_2_r_valid(fsimtop_s_2_axi_rvalid),
@@ -1228,7 +1204,6 @@ wire fsimtop_s_3_axi_rready;
    .io_slave_2_r_bits_data(fsimtop_s_2_axi_rdata),
    .io_slave_2_r_bits_last(fsimtop_s_2_axi_rlast),
    .io_slave_2_r_bits_id(fsimtop_s_2_axi_rid),
-   .io_slave_2_r_bits_user(1'b0), // TODO check this
 
    .io_slave_3_aw_ready(fsimtop_s_3_axi_awready),
    .io_slave_3_aw_valid(fsimtop_s_3_axi_awvalid),
@@ -1240,23 +1215,18 @@ wire fsimtop_s_3_axi_rready;
    .io_slave_3_aw_bits_cache(fsimtop_s_3_axi_awcache), // not available on DDR IF
    .io_slave_3_aw_bits_prot(fsimtop_s_3_axi_awprot), // not available on DDR IF
    .io_slave_3_aw_bits_qos(fsimtop_s_3_axi_awqos), // not available on DDR IF
-   .io_slave_3_aw_bits_region(fsimtop_s_3_axi_awregion), // not available on DDR IF
    .io_slave_3_aw_bits_id(fsimtop_s_3_axi_awid),
-   .io_slave_3_aw_bits_user(), // not available on DDR IF
 
    .io_slave_3_w_ready(fsimtop_s_3_axi_wready),
    .io_slave_3_w_valid(fsimtop_s_3_axi_wvalid),
    .io_slave_3_w_bits_data(fsimtop_s_3_axi_wdata),
    .io_slave_3_w_bits_last(fsimtop_s_3_axi_wlast),
-   .io_slave_3_w_bits_id(),
    .io_slave_3_w_bits_strb(fsimtop_s_3_axi_wstrb),
-   .io_slave_3_w_bits_user(), // not available on DDR IF
 
    .io_slave_3_b_ready(fsimtop_s_3_axi_bready),
    .io_slave_3_b_valid(fsimtop_s_3_axi_bvalid),
    .io_slave_3_b_bits_resp(fsimtop_s_3_axi_bresp),
    .io_slave_3_b_bits_id(fsimtop_s_3_axi_bid),
-   .io_slave_3_b_bits_user(1'b0), // TODO check this
 
    .io_slave_3_ar_ready(fsimtop_s_3_axi_arready),
    .io_slave_3_ar_valid(fsimtop_s_3_axi_arvalid),
@@ -1268,18 +1238,14 @@ wire fsimtop_s_3_axi_rready;
    .io_slave_3_ar_bits_cache(fsimtop_s_3_axi_arcache), // not available on DDR IF
    .io_slave_3_ar_bits_prot(fsimtop_s_3_axi_arprot), // not available on DDR IF
    .io_slave_3_ar_bits_qos(fsimtop_s_3_axi_arqos), // not available on DDR IF
-   .io_slave_3_ar_bits_region(fsimtop_s_3_axi_arregion), // not available on DDR IF
    .io_slave_3_ar_bits_id(fsimtop_s_3_axi_arid), // not available on DDR IF
-   .io_slave_3_ar_bits_user(), // not available on DDR IF
 
    .io_slave_3_r_ready(fsimtop_s_3_axi_rready),
    .io_slave_3_r_valid(fsimtop_s_3_axi_rvalid),
    .io_slave_3_r_bits_resp(fsimtop_s_3_axi_rresp),
    .io_slave_3_r_bits_data(fsimtop_s_3_axi_rdata),
    .io_slave_3_r_bits_last(fsimtop_s_3_axi_rlast),
-   .io_slave_3_r_bits_id(fsimtop_s_3_axi_rid),
-   .io_slave_3_r_bits_user(1'b0) // TODO check this
-
+   .io_slave_3_r_bits_id(fsimtop_s_3_axi_rid)
 );
 
   // assign cl_sh_ddr_awsize = 3'b110;

--- a/hdk/common/shell_v04261818/build/scripts/aws_build_dcp_from_cl.sh
+++ b/hdk/common/shell_v04261818/build/scripts/aws_build_dcp_from_cl.sh
@@ -18,7 +18,7 @@
 # Usage help
 function usage
 {
-    echo "usage: aws_build_dcp_from_cl.sh [ [-script <vivado_script>] | [-strategy BASIC | DEFAULT | EXPLORE | TIMING | CONGESTION] [-clock_recipe_a A0 | A1 | A2] [-clock_recipe_b B0 | B1 | B2 | B3 | B4 | B5] [-clock_recipe_c C0 | C1 | C2 | C3] [-uram_option 2 | 3 | 4] [-vdefine macro1,macro2,macro3,.....,macrox] -foreground] [-notify] | [-h] | [-H] | [-help] ]"
+    echo "usage: aws_build_dcp_from_cl.sh [ [-script <vivado_script>] | [-strategy BASIC | DEFAULT | EXPLORE | TIMING | NORETIMING | CONGESTION] [-clock_recipe_a A0 | A1 | A2] [-clock_recipe_b B0 | B1 | B2 | B3 | B4 | B5] [-clock_recipe_c C0 | C1 | C2 | C3] [-uram_option 2 | 3 | 4] [-vdefine macro1,macro2,macro3,.....,macrox] -foreground] [-notify] | [-h] | [-H] | [-help] ]"
     echo " "
     echo "By default the build is run in the background using nohup so that the"
     echo "process will not be terminated if the terminal window is closed."
@@ -117,7 +117,7 @@ fi
 
 # Check that strategy is valid
 shopt -s extglob
-if [[ $strategy != @(BASIC|DEFAULT|EXPLORE|TIMING|CONGESTION) ]]; then
+if [[ $strategy != @(BASIC|DEFAULT|EXPLORE|TIMING|CONGESTION|NORETIMING) ]]; then
   err_msg "$strategy isn't a valid strategy. Valid strategies are BASIC, DEFAULT, EXPLORE, TIMING and CONGESTION."
   exit 1
 fi

--- a/hdk/common/shell_v04261818/build/scripts/strategy_BASIC.tcl
+++ b/hdk/common/shell_v04261818/build/scripts/strategy_BASIC.tcl
@@ -16,7 +16,7 @@
 source $HDK_SHELL_DIR/build/scripts/params.tcl
 source $HDK_SHELL_DIR/build/scripts/uram_options.tcl
 
-set synth_options "-keep_equivalent_registers $synth_uram_option"
+set synth_options "-keep_equivalent_registers $synth_uram_option -retiming"
 set synth_directive "default"
 
 #Set psip to 1 to enable Physical Synthesis in Placer

--- a/hdk/common/shell_v04261818/build/scripts/strategy_CONGESTION.tcl
+++ b/hdk/common/shell_v04261818/build/scripts/strategy_CONGESTION.tcl
@@ -16,7 +16,7 @@
 source $HDK_SHELL_DIR/build/scripts/params.tcl
 source $HDK_SHELL_DIR/build/scripts/uram_options.tcl
 
-set synth_options "-no_lc -shreg_min_size 10 -control_set_opt_threshold 16 $synth_uram_option"
+set synth_options "-no_lc -shreg_min_size 10 -control_set_opt_threshold 16 $synth_uram_option -retiming"
 set synth_directive "AlternateRoutability"
 
 #Set psip to 1 to enable Physical Synthesis in Placer

--- a/hdk/common/shell_v04261818/build/scripts/strategy_DEFAULT.tcl
+++ b/hdk/common/shell_v04261818/build/scripts/strategy_DEFAULT.tcl
@@ -16,7 +16,7 @@
 source $HDK_SHELL_DIR/build/scripts/params.tcl
 source $HDK_SHELL_DIR/build/scripts/uram_options.tcl
 
-set synth_options "-keep_equivalent_registers -flatten_hierarchy rebuilt $synth_uram_option"
+set synth_options "-keep_equivalent_registers -flatten_hierarchy rebuilt $synth_uram_option -retiming"
 set synth_directive "default"
 
 #Set psip to 1 to enable Physical Synthesis in Placer

--- a/hdk/common/shell_v04261818/build/scripts/strategy_NORETIMING.tcl
+++ b/hdk/common/shell_v04261818/build/scripts/strategy_NORETIMING.tcl
@@ -16,7 +16,7 @@
 source $HDK_SHELL_DIR/build/scripts/params.tcl
 source $HDK_SHELL_DIR/build/scripts/uram_options.tcl
 
-set synth_options "-keep_equivalent_registers -flatten_hierarchy rebuilt $synth_uram_option -retiming"
+set synth_options "-no_lc -shreg_min_size 5 -fsm_extraction one_hot -resource_sharing auto $synth_uram_option"
 set synth_directive "default"
 
 #Set psip to 1 to enable Physical Synthesis in Placer
@@ -25,33 +25,34 @@ set psip 0
 set link 1
 
 set opt 1
-set opt_options     ""
-set opt_directive   "Explore"
+set opt_options    ""
+set opt_directive  "Explore"
 set opt_preHookTcl  "$HDK_SHELL_DIR/build/scripts/check_uram.tcl"
 set opt_postHookTcl "$HDK_SHELL_DIR/build/scripts/apply_debug_constraints.tcl"
 
 set place 1
-set place_options     ""
-set place_directive   "Explore"
-set place_preHookTcl  ""
+set place_options    ""
+set place_directive  "ExtraNetDelay_high"
+set place_preHookTcl ""
 set place_postHookTcl ""
 
 set phys_opt 1
 set phys_options     ""
-set phys_directive   "Explore"
+set phys_directive   ""
+set phys_directive   "AggressiveExplore"
 set phys_preHookTcl  ""
 set phys_postHookTcl ""
 
 set route 1
-set route_options    ""
+set route_options    "-tns_cleanup"
 set route_directive  "Explore"
 set route_preHookTcl ""
 set route_postHookTcl ""
 
-set route_phys_opt 0
-set post_phys_options    ""
-set post_phys_directive  "Explore"
-set post_phys_preHookTcl ""
+set route_phys_opt 1
+set post_phys_options     ""
+set post_phys_directive   "AggressiveExplore"
+set post_phys_preHookTcl  ""
 set post_phys_postHookTcl ""
 
 

--- a/hdk/common/shell_v04261818/build/scripts/strategy_TIMING.tcl
+++ b/hdk/common/shell_v04261818/build/scripts/strategy_TIMING.tcl
@@ -16,7 +16,7 @@
 source $HDK_SHELL_DIR/build/scripts/params.tcl
 source $HDK_SHELL_DIR/build/scripts/uram_options.tcl
 
-set synth_options "-no_lc -shreg_min_size 5 -fsm_extraction one_hot -resource_sharing auto $synth_uram_option"
+set synth_options "-no_lc -shreg_min_size 5 -fsm_extraction one_hot -resource_sharing auto $synth_uram_option -retiming"
 set synth_directive "default"
 
 #Set psip to 1 to enable Physical Synthesis in Placer


### PR DESCRIPTION
### Added
* A strategy for disabling retiming (firesim/aws-fpga-firesim#34)

### Changed
* Unrouted clock nets promoted to error (firesim/aws-fpga-firesim#31)
* Emit hierarchal utilization report in %  firesim/aws-fpga-firesim#37


### Fixed

### Deprecated

### Removed