### PR TITLE
add more reports

### DIFF
--- a/hdk/cl/developer_designs/cl_firesim/build/scripts/create_dcp_from_cl.tcl
+++ b/hdk/cl/developer_designs/cl_firesim/build/scripts/create_dcp_from_cl.tcl
@@ -285,7 +285,7 @@ if {$implement} {
          impl_step opt_design $TOP "-merge_equivalent_drivers -sweep"
       }
    }
-   report_utilization -hierarchical -file $CL_DIR/build/reports/${timestamp}.post_opt_utilization.rpt
+   report_utilization -hierarchical -hierarchical_percentages -file $CL_DIR/build/reports/${timestamp}.post_opt_utilization.rpt
 
    ########################
    # CL Place
@@ -331,7 +331,7 @@ if {$implement} {
    report_timing_summary -file $CL_DIR/build/reports/${timestamp}.SH_CL_final_timing_summary.rpt
 
    # Report utilization
-   report_utilization -hierarchical -file $CL_DIR/build/reports/${timestamp}.SH_CL_utilization.rpt
+   report_utilization -hierarchical -hierarchical_percentages -file $CL_DIR/build/reports/${timestamp}.SH_CL_utilization.rpt
 
    # This is what will deliver to AWS
    puts "AWS FPGA: ([clock format [clock seconds] -format %T]) - Writing final DCP to to_aws directory.";

--- a/hdk/cl/developer_designs/cl_firesim/build/scripts/synth_cl_firesim.tcl
+++ b/hdk/cl/developer_designs/cl_firesim/build/scripts/synth_cl_firesim.tcl
@@ -128,6 +128,9 @@ if { $failval==0 } {
 puts "AWS FPGA: ([clock format [clock seconds] -format %T]) writing post synth checkpoint.";
 write_checkpoint -force $CL_DIR/build/checkpoints/${timestamp}.CL.post_synth.dcp
 
+report_utilization -hierarchical -hierarchical_percentages -file $CL_DIR/build/reports/${timestamp}.post_synth_utilization.rpt
+report_control_sets -verbose -file $CL_DIR/build/reports/${timestamp}.post_synth_control_sets.rpt
+
 close_project
 #Set param back to default value
 set_param sta.enableAutoGenClkNamePersistence 1


### PR DESCRIPTION
use -hierarchical_percentages in report_utilization
seems to indicate percent utilization while obeying hierarchical pblock constraints

report_control_sets after synthesis, gives nice overview of the clocking
in the design. Learned about this report from 
https://forums.xilinx.com/t5/Implementation/Vivado-2014-3-1-place-error-place-30-487/td-p/589987