### PR TITLE
Pull In Generated XDC For Implementation 

### DIFF
--- a/hdk/cl/developer_designs/cl_firesim/build/constraints/cl_pnr_user.xdc
+++ b/hdk/cl/developer_designs/cl_firesim/build/constraints/cl_pnr_user.xdc
@@ -49,3 +49,6 @@ set_false_path -from [get_clocks clk_main_a0] \
 
 
 set_property CLOCK_DEDICATED_ROUTE ANY_CMT_COLUMN [get_nets WRAPPER_INST/SH/kernel_clks_i/clkwiz_sys_clk/inst/CLK_CORE_DRP_I/clk_inst/clk_out2]
+
+# Give the main simulator clock a better name
+create_generated_clock -name host_clock [get_pins WRAPPER_INST/CL/firesim_clocking/inst/mmcme4_adv_inst/CLKOUT0]

--- a/hdk/cl/developer_designs/cl_firesim/build/constraints/cl_pnr_user.xdc
+++ b/hdk/cl/developer_designs/cl_firesim/build/constraints/cl_pnr_user.xdc
@@ -1,9 +1,44 @@
 # This contains the CL specific constraints for Top level PNR
 
-# False paths between main clock and tck
-set_clock_groups -name TIG_SRAI_1 -asynchronous -group [get_clocks -of_objects [get_pins static_sh/SH_DEBUG_BRIDGE/inst/bsip/inst/USE_SOFTBSCAN.U_TAP_TCKBUFG/O]] -group [get_clocks -of_objects [get_pins SH/kernel_clks_i/clkwiz_sys_clk/inst/CLK_CORE_DRP_I/clk_inst/mmcme3_adv_inst/CLKOUT0]]
-set_clock_groups -name TIG_SRAI_2 -asynchronous -group [get_clocks -of_objects [get_pins static_sh/SH_DEBUG_BRIDGE/inst/bsip/inst/USE_SOFTBSCAN.U_TAP_TCKBUFG/O]] -group [get_clocks drck]
-set_clock_groups -name TIG_SRAI_3 -asynchronous -group [get_clocks -of_objects [get_pins static_sh/SH_DEBUG_BRIDGE/inst/bsip/inst/USE_SOFTBSCAN.U_TAP_TCKBUFG/O]] -group [get_clocks -of_objects [get_pins static_sh/pcie_inst/inst/gt_top_i/diablo_gt.diablo_gt_phy_wrapper/phy_clk_i/bufg_gt_userclk/O]]
+create_pblock pblock_CL_top
+add_cells_to_pblock [get_pblocks pblock_CL_top] [get_cells -quiet -hierarchical -filter {NAME =~ WRAPPER_INST/CL/SH_DDR/gen_ddr_tst[0].*}]
+add_cells_to_pblock [get_pblocks pblock_CL_top] [get_cells -quiet -hierarchical -filter {NAME =~ WRAPPER_INST/CL/SH_DDR/ddr_cores.DDR4_0*}]
+add_cells_to_pblock [get_pblocks pblock_CL_top] [get_cells -quiet -hierarchical -filter {NAME =~ WRAPPER_INST/CL/SH_DDR/ddr_inst[0].*}]
+add_cells_to_pblock [get_pblocks pblock_CL_top] [get_cells -quiet -hierarchical -filter {NAME =~ WRAPPER_INST/CL/SH_DDR/ddr_stat[0].*}]
+resize_pblock [get_pblocks pblock_CL_top] -add {CLOCKREGION_X0Y10:CLOCKREGION_X5Y14}
+set_property PARENT pblock_CL [get_pblocks pblock_CL_top]
+
+create_pblock pblock_CL_mid
+add_cells_to_pblock [get_pblocks pblock_CL_mid] [get_cells -quiet -hierarchical -filter {NAME =~ WRAPPER_INST/CL/SH_DDR/gen_ddr_tst[1].*}]
+add_cells_to_pblock [get_pblocks pblock_CL_mid] [get_cells -quiet -hierarchical -filter {NAME =~ WRAPPER_INST/CL/SH_DDR/ddr_cores.DDR4_1*}]
+add_cells_to_pblock [get_pblocks pblock_CL_mid] [get_cells -quiet -hierarchical -filter {NAME =~ WRAPPER_INST/CL/SH_DDR/ddr_inst[1].*}]
+add_cells_to_pblock [get_pblocks pblock_CL_mid] [get_cells -quiet -hierarchical -filter {NAME =~ WRAPPER_INST/CL/SH_DDR/ddr_stat[1].*}]
+#resize_pblock [get_pblocks pblock_CL_mid] -add {CLOCKREGION_X0Y5:CLOCKREGION_X3Y9}
+resize_pblock [get_pblocks pblock_CL_mid] -add {SLICE_X88Y300:SLICE_X107Y599}
+resize_pblock [get_pblocks pblock_CL_mid] -add {DSP48E2_X11Y120:DSP48E2_X13Y239}
+resize_pblock [get_pblocks pblock_CL_mid] -add {LAGUNA_X12Y240:LAGUNA_X15Y479}
+resize_pblock [get_pblocks pblock_CL_mid] -add {RAMB18_X7Y120:RAMB18_X7Y239}
+resize_pblock [get_pblocks pblock_CL_mid] -add {RAMB36_X7Y60:RAMB36_X7Y119}
+resize_pblock [get_pblocks pblock_CL_mid] -add {URAM288_X2Y80:URAM288_X2Y159}
+resize_pblock [get_pblocks pblock_CL_mid] -add {CLOCKREGION_X0Y5:CLOCKREGION_X2Y9}
+set_property SNAPPING_MODE ON [get_pblocks pblock_CL_mid]
+set_property PARENT pblock_CL [get_pblocks pblock_CL_mid]
+
+create_pblock pblock_CL_bot
+add_cells_to_pblock [get_pblocks pblock_CL_bot] [get_cells -quiet -hierarchical -filter {NAME =~ WRAPPER_INST/CL/SH_DDR/gen_ddr_tst[2].*}]
+add_cells_to_pblock [get_pblocks pblock_CL_bot] [get_cells -quiet -hierarchical -filter {NAME =~ WRAPPER_INST/CL/SH_DDR/ddr_cores.DDR4_2*}]
+add_cells_to_pblock [get_pblocks pblock_CL_bot] [get_cells -quiet -hierarchical -filter {NAME =~ WRAPPER_INST/CL/SH_DDR/ddr_inst[2].*}]
+add_cells_to_pblock [get_pblocks pblock_CL_bot] [get_cells -quiet -hierarchical -filter {NAME =~ WRAPPER_INST/CL/SH_DDR/ddr_stat[2].*}]
+#resize_pblock [get_pblocks pblock_CL_bot] -add {CLOCKREGION_X0Y0:CLOCKREGION_X3Y4}
+resize_pblock [get_pblocks pblock_CL_bot] -add {SLICE_X88Y0:SLICE_X107Y299}
+resize_pblock [get_pblocks pblock_CL_bot] -add {DSP48E2_X11Y0:DSP48E2_X13Y119}
+resize_pblock [get_pblocks pblock_CL_bot] -add {LAGUNA_X12Y0:LAGUNA_X15Y239}
+resize_pblock [get_pblocks pblock_CL_bot] -add {RAMB18_X7Y0:RAMB18_X7Y119}
+resize_pblock [get_pblocks pblock_CL_bot] -add {RAMB36_X7Y0:RAMB36_X7Y59}
+resize_pblock [get_pblocks pblock_CL_bot] -add {URAM288_X2Y0:URAM288_X2Y79}
+resize_pblock [get_pblocks pblock_CL_bot] -add {CLOCKREGION_X0Y0:CLOCKREGION_X2Y4}
+set_property SNAPPING_MODE ON [get_pblocks pblock_CL_bot]
+set_property PARENT pblock_CL [get_pblocks pblock_CL_bot]
 
 # False paths to FireSim reset synchronizers
 set_false_path -from [get_clocks clk_main_a0] \

--- a/hdk/cl/developer_designs/cl_firesim/build/scripts/create_dcp_from_cl.tcl
+++ b/hdk/cl/developer_designs/cl_firesim/build/scripts/create_dcp_from_cl.tcl
@@ -267,9 +267,11 @@ if {$implement} {
 
       #Read the constraints, note *DO NOT* read cl_clocks_aws (clocks originating from AWS shell)
       read_xdc [ list \
-         $CL_DIR/build/constraints/cl_pnr_user.xdc
+         $CL_DIR/build/constraints/cl_pnr_user.xdc \
+         $CL_DIR/design/cl_firesim_generated.xdc
       ]
       set_property PROCESSING_ORDER late [get_files cl_pnr_user.xdc]
+      set_property PROCESSING_ORDER late [get_files cl_firesim_generated.xdc]
 
       puts "\nAWS FPGA: ([clock format [clock seconds] -format %T]) - Running link_design";
       link_design -top $TOP -part [DEVICE_TYPE] -reconfig_partitions {WRAPPER_INST/SH WRAPPER_INST/CL}

--- a/hdk/cl/developer_designs/cl_firesim/build/scripts/encrypt.tcl
+++ b/hdk/cl/developer_designs/cl_firesim/build/scripts/encrypt.tcl
@@ -36,9 +36,9 @@ if {[llength [glob -nocomplain -dir $TARGET_DIR *]] != 0} {
 ## Change file names and paths below to reflect your CL area.  DO NOT include AWS RTL files.
 file copy -force $CL_DIR/design/cl_firesim_defines.vh                 $TARGET_DIR
 file copy -force $CL_DIR/design/cl_firesim_generated_defines.vh       $TARGET_DIR
-file copy -force $CL_DIR/design/ila_files/firesim_ila_insert_inst.v   $TARGET_DIR
-file copy -force $CL_DIR/design/ila_files/firesim_ila_insert_ports.v  $TARGET_DIR
-file copy -force $CL_DIR/design/ila_files/firesim_ila_insert_wires.v  $TARGET_DIR
+file copy -force $CL_DIR/design/cl_firesim_generated_ila_insert_inst.v   $TARGET_DIR
+file copy -force $CL_DIR/design/cl_firesim_generated_ila_insert_ports.v  $TARGET_DIR
+file copy -force $CL_DIR/design/cl_firesim_generated_ila_insert_wires.v  $TARGET_DIR
 file copy -force $CL_DIR/design/cl_id_defines.vh                      $TARGET_DIR
 file copy -force $CL_DIR/design/cl_firesim.sv                         $TARGET_DIR 
 file copy -force $CL_DIR/design/cl_firesim_generated.sv               $TARGET_DIR 

--- a/hdk/cl/developer_designs/cl_firesim/design/cl_firesim.sv
+++ b/hdk/cl/developer_designs/cl_firesim/design/cl_firesim.sv
@@ -60,13 +60,13 @@ logic rst_extra1_n_sync;
 // on them
 // See: https://forums.aws.amazon.com/thread.jspa?messageID=939230&#939230
 //-------------------------------------------------
-logic clk_extra_a1_reg;                          //Extra clock A1 (phase aligned to "A" clock group)
-logic clk_extra_a2_reg;                          //Extra clock A2 (phase aligned to "A" clock group)
-logic clk_extra_a3_reg;                          //Extra clock A3 (phase aligned to "A" clock group)
-logic clk_extra_b0_reg;                          //Extra clock B0 (phase aligned to "B" clock group)
-logic clk_extra_b1_reg;                          //Extra clock B1 (phase aligned to "B" clock group)
-logic clk_extra_c0_reg;                          //Extra clock C0 (phase aligned to "B" clock group)
-logic clk_extra_c1_reg;                          //Extra clock C1 (phase aligned to "B" clock group)
+(* dont_touch = "true" *) logic clk_extra_a1_reg;                          //Extra clock A1 (phase aligned to "A" clock group)
+(* dont_touch = "true" *) logic clk_extra_a2_reg;                          //Extra clock A2 (phase aligned to "A" clock group)
+(* dont_touch = "true" *) logic clk_extra_a3_reg;                          //Extra clock A3 (phase aligned to "A" clock group)
+(* dont_touch = "true" *) logic clk_extra_b0_reg;                          //Extra clock B0 (phase aligned to "B" clock group)
+(* dont_touch = "true" *) logic clk_extra_b1_reg;                          //Extra clock B1 (phase aligned to "B" clock group)
+(* dont_touch = "true" *) logic clk_extra_c0_reg;                          //Extra clock C0 (phase aligned to "B" clock group)
+(* dont_touch = "true" *) logic clk_extra_c1_reg;                          //Extra clock C1 (phase aligned to "B" clock group)
 
 always_ff @(posedge clk_extra_a1) begin
     clk_extra_a1_reg <= 1'b1;


### PR DESCRIPTION
This provides the aws-fpga-side support for the multicycle setup constraints. 

It should now be possible to emit stuff like floorplanning constraints and other timing constraints from as far up the pipeline as the target generator. 