### PR TITLE
Add -reference_checkpoint option to aws_build_dcp_from_cl.sh

### DIFF
--- a/hdk/cl/developer_designs/cl_firesim/build/scripts/create_dcp_from_cl.tcl
+++ b/hdk/cl/developer_designs/cl_firesim/build/scripts/create_dcp_from_cl.tcl
@@ -38,6 +38,8 @@ set clock_recipe_c      [lindex $argv 10]
 set uram_option         [lindex $argv 11]
 set notify_via_sns      [lindex $argv 12]
 set VDEFINES            [lindex $argv 13]
+set reference_checkpoint [lindex $argv 14]
+
 ##################################################
 ## Flow control variables 
 ##################################################
@@ -273,6 +275,14 @@ if {$implement} {
    }
 
    ########################
+   # Load Reference Checkpoint (if provided)
+   ########################
+   if {$reference_checkpoint != ""} {
+       read_checkpoint -incremental $reference_checkpoint
+       report_incremental_reuse  -hierarchical -file $CL_DIR/build/reports/${timestamp}.post_link_incremental_reuse.rpt 
+   }
+
+   ########################
    # CL Optimize
    ########################
    set place_preHookTcl  ""
@@ -284,6 +294,9 @@ if {$implement} {
       }
    }
    report_utilization -hierarchical -file $CL_DIR/build/reports/${timestamp}.post_opt_utilization.rpt
+   if {$reference_checkpoint != ""} {
+       report_incremental_reuse  -hierarchical -file $CL_DIR/build/reports/${timestamp}.post_opt_incremental_reuse.rpt 
+   }
 
    ########################
    # CL Place
@@ -327,6 +340,10 @@ if {$implement} {
    ##############################
    # Report final timing
    report_timing_summary -file $CL_DIR/build/reports/${timestamp}.SH_CL_final_timing_summary.rpt
+
+   if {$reference_checkpoint != ""} {
+       report_incremental_reuse  -hierarchical -file $CL_DIR/build/reports/${timestamp}.SH_CL_incremental_reuse.rpt 
+   }
 
    # Report utilization
    report_utilization -hierarchical -file $CL_DIR/build/reports/${timestamp}.SH_CL_utilization.rpt

--- a/hdk/cl/developer_designs/cl_firesim/build/scripts/synth_cl_firesim.tcl
+++ b/hdk/cl/developer_designs/cl_firesim/build/scripts/synth_cl_firesim.tcl
@@ -117,7 +117,9 @@ puts "AWS FPGA: ([clock format [clock seconds] -format %T]) Start design synthes
 
 update_compile_order -fileset sources_1
 puts "\nRunning synth_design for $CL_MODULE $CL_DIR/build/scripts \[[clock format [clock seconds] -format {%a %b %d %H:%M:%S %Y}]\]"
-eval [concat synth_design -top $CL_MODULE -verilog_define XSDB_SLV_DIS $VDEFINES -part [DEVICE_TYPE] -mode out_of_context $synth_options -directive $synth_directive]
+set runcmd [concat synth_design -top $CL_MODULE -verilog_define XSDB_SLV_DIS $VDEFINES -part [DEVICE_TYPE] -mode out_of_context $synth_options -directive $synth_directive]
+puts "\n$runcmd"
+eval $runcmd
 
 set failval [catch {exec grep "FAIL" failfast.csv}]
 if { $failval==0 } {

--- a/hdk/common/shell_v04261818/build/scripts/aws_build_dcp_from_cl.sh
+++ b/hdk/common/shell_v04261818/build/scripts/aws_build_dcp_from_cl.sh
@@ -18,7 +18,7 @@
 # Usage help
 function usage
 {
-    echo "usage: aws_build_dcp_from_cl.sh [ [-script <vivado_script>] | [-strategy BASIC | DEFAULT | EXPLORE | TIMING | NORETIMING | CONGESTION] [-clock_recipe_a A0 | A1 | A2] [-clock_recipe_b B0 | B1 | B2 | B3 | B4 | B5] [-clock_recipe_c C0 | C1 | C2 | C3] [-uram_option 2 | 3 | 4] [-vdefine macro1,macro2,macro3,.....,macrox] -foreground] [-notify] | [-h] | [-H] | [-help] ]"
+    echo "usage: aws_build_dcp_from_cl.sh [ [-script <vivado_script>] | [-strategy BASIC | DEFAULT | EXPLORE | TIMING | NORETIMING | CONGESTION] [-clock_recipe_a A0 | A1 | A2] [-clock_recipe_b B0 | B1 | B2 | B3 | B4 | B5] [-clock_recipe_c C0 | C1 | C2 | C3] [-uram_option 2 | 3 | 4] [-vdefine macro1,macro2,macro3,.....,macrox] -foreground] [-notify] [-reference_checkpoint <dcp>] | [-h] | [-H] | [-help] ]"
     echo " "
     echo "By default the build is run in the background using nohup so that the"
     echo "process will not be terminated if the terminal window is closed."
@@ -45,6 +45,7 @@ ignore_memory_requirement=0
 expected_memory_usage=30000000
 uram_option=2
 vdefine=""
+reference_checkpoint=""
 
 function info_msg {
   echo -e "INFO: $1"
@@ -100,6 +101,9 @@ while [ "$1" != "" ]; do
                                 ;;
         -ignore_memory_requirement) ignore_memory_requirement=1
                                 ;;
+	-reference_checkpoint)  shift
+	                        reference_checkpoint=$1
+				;;
         -h | -H | -help )       usage
                                 exit
                                 ;;
@@ -243,7 +247,7 @@ subsystem_id="0x${id1_version:0:4}";
 subsystem_vendor_id="0x${id1_version:4:4}";
 
 # Run vivado
-cmd="vivado -mode batch -nojournal -log $logname -source $vivado_script -tclargs $timestamp $strategy $hdk_version $shell_version $device_id $vendor_id $subsystem_id $subsystem_vendor_id $clock_recipe_a $clock_recipe_b $clock_recipe_c $uram_option $notify $opt_vdefine"
+cmd="vivado -mode batch -nojournal -log $logname -source $vivado_script -tclargs $timestamp $strategy $hdk_version $shell_version $device_id $vendor_id $subsystem_id $subsystem_vendor_id $clock_recipe_a $clock_recipe_b $clock_recipe_c $uram_option $notify $opt_vdefine $reference_checkpoint"
 if [[ "$foreground" == "0" ]]; then
   nohup $cmd > $timestamp.nohup.out 2>&1 &
   


### PR DESCRIPTION
If passed, the path given to -reference_checkpoint is used to
`read_checkpoint -incremental` at the appropriate place in the
design flow for Vivado to do an incremental implementation

Also adds `report_incremental_reuse -hierarchical` reporting
at the various stages of the flow.