### PR TITLE
Floorplan CDC + width adapters into same SLR as their associated DRAM controller

### DIFF
--- a/hdk/cl/developer_designs/cl_firesim/build/constraints/cl_pnr_user.xdc
+++ b/hdk/cl/developer_designs/cl_firesim/build/constraints/cl_pnr_user.xdc
@@ -49,3 +49,21 @@ set_false_path -from [get_clocks clk_main_a0] \
 
 
 set_property CLOCK_DEDICATED_ROUTE ANY_CMT_COLUMN [get_nets WRAPPER_INST/SH/kernel_clks_i/clkwiz_sys_clk/inst/CLK_CORE_DRP_I/clk_inst/clk_out2]
+
+
+# FireSim added CDC + width adapters
+# SH DDR (Channel C)
+add_cells_to_pblock [get_pblocks pblock_CL_mid] [get_cells -quiet WRAPPER_INST/CL/clock_convert_dramslim_0]
+add_cells_to_pblock [get_pblocks pblock_CL_mid] [get_cells -quiet WRAPPER_INST/CL/dwidth_adapt_64bits_512bits]
+
+# CL DDR A
+add_cells_to_pblock [get_pblocks pblock_CL_top] [get_cells -quiet WRAPPER_INST/CL/clock_convert_dramslim_1]
+add_cells_to_pblock [get_pblocks pblock_CL_top] [get_cells -quiet WRAPPER_INST/CL/dwidth_adapt_64bits_512bits_1]
+
+# CL DDR B
+add_cells_to_pblock [get_pblocks pblock_CL_mid] [get_cells -quiet WRAPPER_INST/CL/clock_convert_dramslim_2]
+add_cells_to_pblock [get_pblocks pblock_CL_mid] [get_cells -quiet WRAPPER_INST/CL/dwidth_adapt_64bits_512bits_2]
+
+# CL DDR D
+add_cells_to_pblock [get_pblocks pblock_CL_bot] [get_cells -quiet WRAPPER_INST/CL/clock_convert_dramslim_3]
+add_cells_to_pblock [get_pblocks pblock_CL_bot] [get_cells -quiet WRAPPER_INST/CL/dwidth_adapt_64bits_512bits_3]

--- a/hdk/cl/developer_designs/cl_firesim/build/constraints/cl_pnr_user.xdc
+++ b/hdk/cl/developer_designs/cl_firesim/build/constraints/cl_pnr_user.xdc
@@ -54,7 +54,7 @@ set_property CLOCK_DEDICATED_ROUTE ANY_CMT_COLUMN [get_nets WRAPPER_INST/SH/kern
 # FireSim added CDC + width adapters
 # SH DDR (Channel C)
 add_cells_to_pblock [get_pblocks pblock_CL_mid] [get_cells -quiet WRAPPER_INST/CL/clock_convert_dramslim_0]
-add_cells_to_pblock [get_pblocks pblock_CL_mid] [get_cells -quiet WRAPPER_INST/CL/dwidth_adapt_64bits_512bits]
+add_cells_to_pblock [get_pblocks pblock_CL_mid] [get_cells -quiet WRAPPER_INST/CL/dwidth_adapt_64bits_512bits_0]
 
 # CL DDR A
 add_cells_to_pblock [get_pblocks pblock_CL_top] [get_cells -quiet WRAPPER_INST/CL/clock_convert_dramslim_1]

--- a/hdk/cl/developer_designs/cl_firesim/design/cl_firesim.sv
+++ b/hdk/cl/developer_designs/cl_firesim/design/cl_firesim.sv
@@ -1455,7 +1455,7 @@ assign cl_sh_ddr_arid = 16'b0; // dwidth convert has no arid for some reason...
 // unused: sh_cl_ddr_bid
 // unused: sh_cl_ddr_rid
 
-axi_dwidth_converter_0 dwidth_adapt_64bits_512bits (
+axi_dwidth_converter_0 dwidth_adapt_64bits_512bits_0 (
   .s_axi_aclk(clk_main_a0),          // input wire s_axi_aclk
   .s_axi_aresetn(rst_main_n_sync),    // input wire s_axi_aresetn
 


### PR DESCRIPTION
Vivado can put these circuits in very odd places, leading to a poor cross-section of signals crossing SLRs. 

In the future we could consider adding an AXI4 register slice with auto-pipeline insertion enabled between the simulator and the width adapter. With the right annotations i think we can do this from vanilla chisel. 
