### PR TITLE
Disable source encryption to de-obfuscate names

### DIFF
--- a/hdk/cl/developer_designs/cl_firesim/build/scripts/create_dcp_from_cl.tcl
+++ b/hdk/cl/developer_designs/cl_firesim/build/scripts/create_dcp_from_cl.tcl
@@ -213,8 +213,9 @@ switch $strategy {
 #set phys_opt 0
 set phys_opt 1
 
-puts "AWS FPGA: ([clock format [clock seconds] -format %T]) Calling the encrypt.tcl.";
-
+#puts "AWS FPGA: ([clock format [clock seconds] -format %T]) Calling the encrypt.tcl.";
+# FireSim: note, this only moves sources into the encrypt directory without
+# actually encrypting them. Modify encrypt.tcl to renable CL-source encryption.
 #Encrypt source code
 source encrypt.tcl
 

--- a/hdk/cl/developer_designs/cl_firesim/build/scripts/create_dcp_from_cl.tcl
+++ b/hdk/cl/developer_designs/cl_firesim/build/scripts/create_dcp_from_cl.tcl
@@ -213,8 +213,10 @@ switch $strategy {
 #set phys_opt 0
 set phys_opt 1
 
-#puts "AWS FPGA: ([clock format [clock seconds] -format %T]) Calling the encrypt.tcl.";
-# FireSim: note, this only moves sources into the encrypt directory without actually encrypting them.
+#puts "AWS FPGA: ([clock format [clock seconds] -format %T]) Calling the encrypt.tcl."
+# Source encryption renders timing reports and checkpoints unsuable because it obfuscates net names, so in FireSim we've disabled it.
+# However, to minimize divergence between FireSim's fork and upstream, we've achieved this by modifying encrypt.tcl to move sources
+# into the existing encrypted source directory (where the rest of the build expects them) without actually encrypting them.
 # See comment in encrypt.tcl for more detail.
 #Encrypt source code
 source encrypt.tcl

--- a/hdk/cl/developer_designs/cl_firesim/build/scripts/create_dcp_from_cl.tcl
+++ b/hdk/cl/developer_designs/cl_firesim/build/scripts/create_dcp_from_cl.tcl
@@ -214,8 +214,8 @@ switch $strategy {
 set phys_opt 1
 
 #puts "AWS FPGA: ([clock format [clock seconds] -format %T]) Calling the encrypt.tcl.";
-# FireSim: note, this only moves sources into the encrypt directory without
-# actually encrypting them. Modify encrypt.tcl to renable CL-source encryption.
+# FireSim: note, this only moves sources into the encrypt directory without actually encrypting them.
+# See comment in encrypt.tcl for more detail.
 #Encrypt source code
 source encrypt.tcl
 

--- a/hdk/cl/developer_designs/cl_firesim/build/scripts/encrypt.tcl
+++ b/hdk/cl/developer_designs/cl_firesim/build/scripts/encrypt.tcl
@@ -70,6 +70,7 @@ puts "vivado_version $vivado_version"
 # checkpoints and timing reports making it difficult to analyze build
 # difficulties without rerunning a build with encryption disabled.
 # The final checkpoint is still encrypted before delivery to AWS.
+# See https://forums.aws.amazon.com/thread.jspa?threadID=346135&tstart=0 
 
 # encrypt .v/.sv/.vh/inc as verilog files
 #

--- a/hdk/cl/developer_designs/cl_firesim/build/scripts/encrypt.tcl
+++ b/hdk/cl/developer_designs/cl_firesim/build/scripts/encrypt.tcl
@@ -66,7 +66,13 @@ set vivado_version [string range [version -short] 0 5]
 puts "AWS FPGA: VIVADO_TOOL_VERSION $TOOL_VERSION"
 puts "vivado_version $vivado_version"
 
+# FireSim: disable encryption of CL RTL since it obfuscates names in
+# checkpoints and timing reports making it difficult to analyze build
+# difficulties without rerunning a build with encryption disabled.
+# The final checkpoint is still encrypted before delivery to AWS.
+
 # encrypt .v/.sv/.vh/inc as verilog files
-encrypt -k $HDK_SHELL_DIR/build/scripts/vivado_keyfile_2017_4.txt -lang verilog  [glob -nocomplain -- $TARGET_DIR/*.{v,sv}] [glob -nocomplain -- $TARGET_DIR/*.vh] [glob -nocomplain -- $TARGET_DIR/*.inc]
+#
+#encrypt -k $HDK_SHELL_DIR/build/scripts/vivado_keyfile_2017_4.txt -lang verilog  [glob -nocomplain -- $TARGET_DIR/*.{v,sv}] [glob -nocomplain -- $TARGET_DIR/*.vh] [glob -nocomplain -- $TARGET_DIR/*.inc]
 # encrypt *vhdl files
-encrypt -k $HDK_SHELL_DIR/build/scripts/vivado_vhdl_keyfile_2017_4.txt -lang vhdl -quiet [ glob -nocomplain -- $TARGET_DIR/*.vhd? ]
+#encrypt -k $HDK_SHELL_DIR/build/scripts/vivado_vhdl_keyfile_2017_4.txt -lang vhdl -quiet [ glob -nocomplain -- $TARGET_DIR/*.vhd? ]


### PR DESCRIPTION
Vivado is now more thorough in its obfuscation of names after source encryption. This renders the timing reports useless, and makes it difficult to interact with checkpoints. Since source encryption is useful only if we wish to share checkpoints with a third party, in this PR I disable source encryption to workaround these problems (our designs are also open source...). 

See https://forums.aws.amazon.com/thread.jspa?threadID=346135&tstart=0 for more discussion.

More consideration:
- Maybe we don't need auto ILA and can just use `mark_debug` inline attributes?