### PR TITLE
Fix "TclStackFree: incorrect freePtr. Call out of sequence?" bug

### DIFF
--- a/hdk/cl/developer_designs/cl_firesim/build/scripts/synth_cl_firesim.tcl
+++ b/hdk/cl/developer_designs/cl_firesim/build/scripts/synth_cl_firesim.tcl
@@ -116,6 +116,8 @@ set_property PROCESSING_ORDER EARLY  [get_files cl_clocks_aws.xdc]
 puts "AWS FPGA: ([clock format [clock seconds] -format %T]) Start design synthesis.";
 
 update_compile_order -fileset sources_1
+# Fix "TclStackFree: incorrect freePtr. Call out of sequence?" bug - https://support.xilinx.com/s/article/55687?language=en_US
+set_param synth.elaboration.rodinMoreOptions {set rt::extractNetlistGenomes false}
 puts "\nRunning synth_design for $CL_MODULE $CL_DIR/build/scripts \[[clock format [clock seconds] -format {%a %b %d %H:%M:%S %Y}]\]"
 eval [concat synth_design -top $CL_MODULE -verilog_define XSDB_SLV_DIS $VDEFINES -part [DEVICE_TYPE] -mode out_of_context $synth_options -directive $synth_directive]
 


### PR DESCRIPTION
When running a large design (MegaBoomConfig w/ Larger L1/L2/LLC w/ Default Hwacha and different DDR3 setup), I get the following error "TclStackFree: incorrect freePtr. Call out of sequence?" and synthesis fails with no logs. Tracing back the issue on the forums seems to indicate that adding `set_param synth.elaboration.rodinMoreOptions {set rt::extractNetlistGenomes false}` solves the issue. In my case, it actually does fix the issue, and synthesis passes. I'm not sure what the impact is / what the flag does but when I have the chance I'll look into it and report back here.

Forum Post: https://support.xilinx.com/s/article/55687?language=en_US