### PR TITLE
ignore report_ip_status output from hdk_setup.sh

### DIFF
--- a/hdk/common/verif/scripts/.gitignore
+++ b/hdk/common/verif/scripts/.gitignore
@@ -1,2 +1,3 @@
 .done
 tmp
+ddr4_core_ip_report.txt


### PR DESCRIPTION
Seems that newer hdk_setup.sh from upstream writes report_ip_status to a file here.

We don't need this to be reported by git and included in the REPO_STATUS for all builds.