### PR TITLE
Remove static URAM constraints on Stream Queues

### DIFF
--- a/hdk/cl/developer_designs/cl_firesim/build/constraints/cl_synth_user.xdc
+++ b/hdk/cl/developer_designs/cl_firesim/build/constraints/cl_synth_user.xdc
@@ -1,3 +1,5 @@
 # This contains the CL specific constraints for synthesis at the CL level
 
-set_property RAM_STYLE ULTRA [get_cells -hierarchical -regexp firesim_top.*PCISdat/fq/ram_reg.*]
+# Add F1 specific constraints here -- constraints common to different FPGA host
+# platforms should be generated during Golden Gate compilation to ensure
+# portability.  See XDCAnnotation + WriteXDCFile pass for more information.


### PR DESCRIPTION
These should be generated by Golden Gate. 

Part of https://github.com/firesim/firesim/pull/1021.