### PR TITLE
Remove legacy AutoILA instantiation + invoke ipgen scripts 

### DIFF
--- a/hdk/cl/developer_designs/cl_firesim/build/scripts/encrypt.tcl
+++ b/hdk/cl/developer_designs/cl_firesim/build/scripts/encrypt.tcl
@@ -36,9 +36,6 @@ if {[llength [glob -nocomplain -dir $TARGET_DIR *]] != 0} {
 ## Change file names and paths below to reflect your CL area.  DO NOT include AWS RTL files.
 file copy -force $CL_DIR/design/cl_firesim_defines.vh                 $TARGET_DIR
 file copy -force $CL_DIR/design/FireSim-generated.defines.vh          $TARGET_DIR
-file copy -force $CL_DIR/design/FireSim-generated.ila_insert_inst.v   $TARGET_DIR
-file copy -force $CL_DIR/design/FireSim-generated.ila_insert_ports.v  $TARGET_DIR
-file copy -force $CL_DIR/design/FireSim-generated.ila_insert_wires.v  $TARGET_DIR
 file copy -force $CL_DIR/design/cl_id_defines.vh                      $TARGET_DIR
 file copy -force $CL_DIR/design/cl_firesim.sv                         $TARGET_DIR
 file copy -force $CL_DIR/design/FireSim-generated.sv                  $TARGET_DIR

--- a/hdk/cl/developer_designs/cl_firesim/build/scripts/synth_cl_firesim.tcl
+++ b/hdk/cl/developer_designs/cl_firesim/build/scripts/synth_cl_firesim.tcl
@@ -7,7 +7,7 @@ create_project -in_memory -part [DEVICE_TYPE] -force
 
 # Generate IP instantated in Golden-Gate generated RTL
 file mkdir $CL_DIR/design/ipgen
-set ipgen_scripts [glob $CL_DIR/design/FireSim-generated.*.ipgen.tcl]
+set ipgen_scripts [glob -nocomplain $CL_DIR/design/FireSim-generated.*.ipgen.tcl]
 foreach script $ipgen_scripts {
     source $script
 }

--- a/hdk/cl/developer_designs/cl_firesim/build/scripts/synth_cl_firesim.tcl
+++ b/hdk/cl/developer_designs/cl_firesim/build/scripts/synth_cl_firesim.tcl
@@ -1,12 +1,3 @@
-########################################
-## Generate ILA based on Recipe 
-########################################
-
-puts "AWS FPGA: ([clock format [clock seconds] -format %T]) Calling firesim_ila_insert_vivado.tcl to generate ILAs from developer's specified recipe.";
-
-source $CL_DIR/design/FireSim-generated.ila_insert_vivado.tcl
-
-
 #Param needed to avoid clock name collisions
 set_param sta.enableAutoGenClkNamePersistence 0
 set CL_MODULE $CL_MODULE
@@ -69,7 +60,7 @@ read_ip [ list \
 
 #Read IP for virtual jtag / ILA/VIO
 read_ip [ list \
-  $HDK_SHELL_DESIGN_DIR/ip/ila_0/ila_0.xci\
+  $HDK_SHELL_DESIGN_DIR/ip/ila_0/ila_0.xci \
   $HDK_SHELL_DESIGN_DIR/ip/cl_debug_bridge/cl_debug_bridge.xci \
   $HDK_SHELL_DESIGN_DIR/ip/ila_vio_counter/ila_vio_counter.xci \
   $HDK_SHELL_DESIGN_DIR/ip/vio_0/vio_0.xci \
@@ -77,8 +68,7 @@ read_ip [ list \
   $CL_DIR/ip/axi_clock_converter_dramslim/axi_clock_converter_dramslim.xci \
   $CL_DIR/ip/axi_clock_converter_oclnew/axi_clock_converter_oclnew.xci \
   $CL_DIR/ip/axi_clock_converter_512_wide/axi_clock_converter_512_wide.xci \
-  $CL_DIR/ip/axi_dwidth_converter_0/axi_dwidth_converter_0.xci \
-  $CL_DIR/ip/firesim_ila_ip/ila_firesim_0/ila_firesim_0.xci
+  $CL_DIR/ip/axi_dwidth_converter_0/axi_dwidth_converter_0.xci
 ]
 
 # Additional IP's that might be needed if using the DDR

--- a/hdk/cl/developer_designs/cl_firesim/build/scripts/synth_cl_firesim.tcl
+++ b/hdk/cl/developer_designs/cl_firesim/build/scripts/synth_cl_firesim.tcl
@@ -5,6 +5,20 @@ set VDEFINES $VDEFINES
 
 create_project -in_memory -part [DEVICE_TYPE] -force
 
+# Generate IP instantated in Golden-Gate generated RTL
+file mkdir $CL_DIR/design/ipgen
+set ipgen_scripts [glob $CL_DIR/design/FireSim-generated.*.ipgen.tcl]
+foreach script $ipgen_scripts {
+    source $script
+}
+
+# Generate targets for all IPs contained within the generated module hierarchy.
+# With the exception of the PLL, these are the only IP instances that don't have
+# their output artifacts checked in.
+generate_target all [get_ips]
+
+synth_ip [get_ips]
+
 ########################################
 ## Generate clocks based on Recipe 
 ########################################

--- a/hdk/cl/developer_designs/cl_firesim/design/cl_firesim.sv
+++ b/hdk/cl/developer_designs/cl_firesim/design/cl_firesim.sv
@@ -1016,11 +1016,6 @@ wire fsimtop_s_3_axi_rvalid;
 wire fsimtop_s_3_axi_rready;
 
 
-
-
-
-`include "FireSim-generated.ila_insert_wires.v"
-
   F1Shim firesim_top (
    .clock(firesim_internal_clock),
    .reset(!rst_firesim_n_sync),
@@ -1116,8 +1111,6 @@ wire fsimtop_s_3_axi_rready;
    .io_dma_r_bits_last(cl_sh_dma_pcis_rlast_FIRESIM),
    .io_dma_r_bits_id(cl_sh_dma_pcis_rid_FIRESIM),
    .io_dma_r_bits_user(),    // UNUSED at top level
-
-   `include "FireSim-generated.ila_insert_ports.v"
 
    .io_slave_0_aw_ready(fsimtop_s_0_axi_awready),
    .io_slave_0_aw_valid(fsimtop_s_0_axi_awvalid),
@@ -2459,8 +2452,6 @@ assign zeroila = 64'b0;
                    .probe4 (zeroila),
                    .probe5 (zeroila)
                    );
-
-`include "FireSim-generated.ila_insert_inst.v"
 
 // Debug Bridge 
  cl_debug_bridge CL_DEBUG_BRIDGE (


### PR DESCRIPTION
See https://github.com/firesim/firesim/pull/1059. 

The name and structure of ip generation scripts will be codified in the local fpga branch, so that the names of these scripts and the directory in which they are invoked are defined in Scala. What i've done here matches what is done in local-fpga.