### PR TITLE
Remove git clean invocation from DRAM model generation

### DIFF
--- a/hdk/common/verif/scripts/Makefile
+++ b/hdk/common/verif/scripts/Makefile
@@ -20,12 +20,23 @@ DEPS_FILE := $(HDK_SHELL_DESIGN_DIR)/ip/ddr4_core/ddr4_core.xci
 DEPS_FILE += $(HDK_COMMON_DIR)/verif/scripts/init.tcl
 DEPS_FILE += $(HDK_COMMON_DIR)/verif/scripts/init.sh
 
+# Replace upstream aws-fpga's use of git clean with an explicit rm -rf
+# Note, it is likely only tmp/ that has to be removed, but all the files
+# that would generally be removed are included here.
+#   git clean -fXdq $(shell dirname $@)
+
+CLEAN_TARGETS += $(HDK_COMMON_DIR)/verif/scripts/ddr4_core_ip_report.txt
+CLEAN_TARGETS += $(HDK_COMMON_DIR)/verif/scripts/tmp/
+# These are inoffensive, but i've put them here for consistency
+CLEAN_TARGETS += $(wildcard $(HDK_COMMON_DIR)/verif/scripts/vivado*.jou)
+CLEAN_TARGETS += $(wildcard $(HDK_COMMON_DIR)/verif/scripts/vivado*.log)
+
 all: $(DONE_FILE)
 
 $(DONE_FILE): $(DEPS_FILE)
 	@ echo "INFO: Building in $(shell dirname $@)"
 	@ echo "INFO: This could take 5-10 minutes, please be patient!"
-	@ git clean -fXdq $(shell dirname $@)
+	@ rm -rf $(CLEAN_TARGETS)
 	@ cd $(shell dirname $@)\
 	&& ./init.sh $(MODEL_DIR)\
 	&& echo "INFO: DDR4 model build passed."\


### PR DESCRIPTION
This has been a recurring problem in a variety of different cases so i've jsut gone ahead and replaced it.

Most notably, for some versions of git, aws-fpga's `.git` wants to refer to firesim's `.git` which is not copied over for bitstream builds (nor should it be). 
